### PR TITLE
padding-top correction for title in SignInSection

### DIFF
--- a/src/components/SignInSection/SignInSection.module.css
+++ b/src/components/SignInSection/SignInSection.module.css
@@ -57,7 +57,7 @@ h2 {
 
 @media screen and (min-width: 1440px) {
   .title {
-    padding-top: 113px;
+    padding-top: 80px;
   }
 }
 


### PR DESCRIPTION
Якщо відпрацьовує обидві помилки в формі під інпутами - то нижнє речення майже випадає з форми  - Тому я виправила верхній падінг, щоб воно було як слід. Цe не по макету - але в нас додались два нових елемента не по макету - тому змінюю верхній падінг з 1440 px 