### PR TITLE
validation input-email with matches(regex)

### DIFF
--- a/src/components/SignInForm/SignInForm.jsx
+++ b/src/components/SignInForm/SignInForm.jsx
@@ -11,7 +11,12 @@ import { getOAuthURL, login } from '../../redux/auth/operations';
 import { selectOAuthURL } from '../../redux/auth/selectors';
 
 const validationSchema = Yup.object().shape({
-  email: Yup.string().email('Must be a valid email').required('Required'),
+  email: Yup.string()
+    .matches(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/, {
+      message: 'Must be a valid email',
+      excludeEmptyString: true,
+    })
+    .required('Required'),
   password: Yup.string()
     .min(6, 'Password must contain at least 6 characters')
     .required('Required'),
@@ -68,11 +73,13 @@ const SignInForm = () => {
             <input
               id={emailId}
               {...register('email')}
-              type="email"
+              type="text"
               placeholder={t('signIn.placeholderEmail')}
               className={`${styles.input} ${
                 errors.email ? styles.errorInpt : ''
               }`}
+              autoComplete="email"
+              inputMode="email"
             />
             {errors.email && (
               <div className={styles.error}>{errors.email.message}</div>

--- a/src/components/SignInForm/SignInForm.module.css
+++ b/src/components/SignInForm/SignInForm.module.css
@@ -42,6 +42,7 @@
   flex-direction: column;
   gap: 16px;
 }
+
 .input {
   border-radius: 15px;
   border: 1px solid var(--border-color);

--- a/src/components/SignUpForm/SignUpForm.jsx
+++ b/src/components/SignUpForm/SignUpForm.jsx
@@ -10,7 +10,12 @@ import { register as signUp } from '../../redux/auth/operations';
 import { useDispatch } from 'react-redux';
 
 const validationSchema = Yup.object().shape({
-  email: Yup.string().email('Must be a valid email').required('Required'),
+  email: Yup.string()
+    .matches(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/, {
+      message: 'Must be a valid email',
+      excludeEmptyString: true,
+    })
+    .required('Required'),
   password: Yup.string()
     .min(6, 'Password must contain at least 6 characters')
     .required('Required'),
@@ -61,11 +66,13 @@ const SignUpForm = () => {
           <input
             id={emailId}
             {...register('email')}
-            type="email"
+            type="text"
             placeholder={t('signUp.placeholderEmail')}
             className={`${styles.input} ${
               errors.email ? styles.errorInpt : ''
             }`}
+            autoComplete="email"
+            inputMode="email"
           />
           {errors.email && (
             <div className={styles.error}>{errors.email.message}</div>

--- a/src/components/SignUpSection/SignUpSection.module.css
+++ b/src/components/SignUpSection/SignUpSection.module.css
@@ -43,7 +43,7 @@ h2 {
   font-weight: 700;
   line-height: 1;
   letter-spacing: -0.32px;
-  padding-top: 172px;
+  padding-top: 150px;
 }
 
 @media screen and (min-width: 768px) {
@@ -57,7 +57,7 @@ h2 {
 
 @media screen and (min-width: 1440px) {
   .title {
-    padding-top: 113px;
+    padding-top: 60px;
   }
 }
 


### PR DESCRIPTION
Довелося змінити тип інпута на **type=text**. Тому що коли type = email - то браузер автоматично обробляє введене значення  i робить перетворення некоректних символів та застосовує кодування Punycode для доменних імен, що містять символи, які не є частиною стандартного ASCII (такі як **кирилиця**). 
Тобто коли я вводжу **123@ыыы.com** в мене в консоль браузер пише  **123@xn--01aaa.com**
Він сам перетворює - і тому я не могла відловити цю кирилицю ніякими регулярними виразами довго)) Поки не вставила .test () і в нього console.log - і тоді я побачила чому ж воно так відбувається.
Тепер все працює та обробляється в регулярному виразі! Також додала - обов'язкову наявність імені домену верхнього рівня після крапки - .com або .uk ... тощо - в regex я маю на увазі)
Стандартний метод .email їx прибрала - він тепер зайвий.
Додала  до інпута autoComplete="email" та  inputMode="email" 
Змінила падінги верхні тепер в SignUp ще - щоб воно не вивалювалось коли помилки відпрацьовують